### PR TITLE
Support #![no_std] environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Lliw provides colours for your terminal, with no additional dependencies.
 # Aims
 
 - No dependencies
+- Works in `#![no_std]` environments
 - Provides colours and styles in a non-opinionated way
 - Provides multiple ways to use
 - Doesn't make your code look like trash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // Zero crate colour library
+#![no_std]
 #![warn(clippy::pedantic, clippy::all)]
-use std::fmt;
+use core::fmt;
 
 // Foreground colours
 pub const FG_BLACK: &str = "[38;5;0m";


### PR DESCRIPTION
Fantastic crate! I noticed the code is super simple and can work without the standard library.

This PR simply adds `#![no_std]` to the top of `lib.rs` and specifies the use of
```rust
core::fmt
```
over
```rust
std::fmt
```

Through these small changes, `lliw` will now work as a dependency of `no_std` projects.